### PR TITLE
handle rate limiting by discord

### DIFF
--- a/SendRedditToDiscord.ps1
+++ b/SendRedditToDiscord.ps1
@@ -75,8 +75,12 @@ function Send-RedditToDiscord
             }
 
 
-            #Write-Verbose "Sending $url to Discord."
-            Invoke-RestMethod -Uri $hookUri -Method Post -Body ($payload | ConvertTo-Json) | Out-Null
+            
+            $Response = try {Invoke-RestMethod -Uri $hookUri -Method Post -Body ($payload | ConvertTo-Json) } catch { $_.Exception.Response }
+            if($Response.StatusCode -eq 429) {
+                Write-Error "We have been rate limited."
+                Break
+            }
             
             if($Count -gt 1) {
                 Start-Sleep -Seconds 1 | Out-Null
@@ -85,6 +89,7 @@ function Send-RedditToDiscord
     }
     End
     {
+        # Fix this later to use actual count rather than requested count.
         Write-Output "Sent $Count posts from https://old.reddit.com/r/$($subreddit) to Discord."
     }
 }


### PR DESCRIPTION
# Catch exception from Invoke-RestMethod POST to Discord and breaks if status code -eq 429.